### PR TITLE
partial embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ In markdown, write code block as follows:
 　```
 
   And, you can refer specific lines as
-
   ```python:tests/src/sample.py [4-5]
 
-```
+  ```
 ```
 
 Then, this action referes to `tests/src/sample.py` and modifies markdown as (if something code is written, they are overridden):

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In markdown, write code block as follows:
   And, you can refer specific lines as
   ```python:tests/src/sample.py [4-5]
 
-  ```
+```
 ```
 
 Then, this action referes to `tests/src/sample.py` and modifies markdown as (if something code is written, they are overridden):
@@ -35,7 +35,7 @@ And, specific lines is refered as
 
 ```python:tests/src/sample.py [4-5]
 def sample(x):
-
+    return sqrt(x)
 ```
 
 NOTE: Read file by passed path, where the top directory in your repo is working directory. If the path is wrong, this action is failed.

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ See [demo repo](https://github.com/tokusumi/readme-code-testing) if you are inte
 
 ## How to use
 
-In markdown, write code block as follows:
+In markdown, write code block as follows (notice that escape sequence "\\" must be eliminated):
 
 ```markdown
-　```python:tests/src/sample.py
-　
-　```
+　\```python:tests/src/sample.py
+ 
+　\```
 
   And, you can refer specific lines as
-  ```python:tests/src/sample.py [4-5]
+  \```python:tests/src/sample.py [4-5]
   
-  ```
+  \```
 ```
 
 Then, this action referes to `tests/src/sample.py` and modifies markdown as (if something code is written, they are overridden):

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ In markdown, write code block as follows:
 　```python:tests/src/sample.py
 　
 　```
+
+  And, you can refer specific lines as
+
+  ```python:tests/src/sample.py [4-5]
+
+  ```
 ```
 
 Then, this action referes to `tests/src/sample.py` and modifies markdown as (if something code is written, they are overridden):
@@ -23,6 +29,12 @@ from math import sqrt
 
 def sample(x):
     return sqrt(x)
+
+```
+
+And, specific lines is refered as
+
+```python:tests/src/sample.py [4-5]
 
 ```
 
@@ -47,18 +59,12 @@ jobs:
       - uses: actions/checkout@v2
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+          ref: refs/heads/${{ github.head_ref }}
 
       - uses: tokusumi/markdown-embed-code@main
         with:
           markdown: "README.md"
-      - name: Commit files
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git commit -m "Embedding code into Markdown" -a
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          message: "synchronizing Readme"
+          silent: true
 ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ In markdown, write code block as follows:
 
   And, you can refer specific lines as
   ```python:tests/src/sample.py [4-5]
-
-```
+  
+  ```
 ```
 
 Then, this action referes to `tests/src/sample.py` and modifies markdown as (if something code is written, they are overridden):

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In markdown, write code block as follows:
 
   ```python:tests/src/sample.py [4-5]
 
-  ```
+```
 ```
 
 Then, this action referes to `tests/src/sample.py` and modifies markdown as (if something code is written, they are overridden):
@@ -35,6 +35,7 @@ def sample(x):
 And, specific lines is refered as
 
 ```python:tests/src/sample.py [4-5]
+def sample(x):
 
 ```
 

--- a/markdown_embed_code/__init__.py
+++ b/markdown_embed_code/__init__.py
@@ -18,7 +18,7 @@ def parse(option: str) -> Tuple[Path, int, Optional[int]]:
             return file_path, start, None
         elif len(idxs) == 2:
             start = 0 if not idxs[0] else int(idxs[0]) - 1
-            end = None if not idxs[1] else int(idxs[1]) - 1
+            end = None if not idxs[1] else int(idxs[1])
             return file_path, start, end
     return file_path, 0, None
 
@@ -35,12 +35,15 @@ class MarkdownEmbEodeRenderer(MarkdownRenderer):
         file_path, start, end = parse(option)
         with file_path.open() as f:
             if start == 0 and end is None:
-                code = f.read()
+                code = f.read() + "\n"
             elif end is None:
-                code = "".join(f.readlines()[start:])
+                code = "".join(f.readlines()[start:]) + "\n"
             else:
-                code = "".join(f.readlines()[start:end])
-        element.children[0].children = f"{code}\n"
+                out = f.readlines()
+                code = "".join(out[start:end])
+                if len(out) < end:
+                    code += "\n"
+        element.children[0].children = code
         return super().render_fenced_code(element)
 
     def render_image(self, element):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,8 +47,8 @@ def test_ignore_no_filepath():
 @pytest.mark.parametrize(
     "lang",
     [
-        "python:tests/src/sample.py[4-6]",
-        "python:tests/src/sample.py [4-6]",
+        "python:tests/src/sample.py[4-5]",
+        "python:tests/src/sample.py [4-5]",
     ],
 )
 def test_embed_code_only_specific_line_from_file(lang):
@@ -60,7 +60,6 @@ def test_embed_code_only_specific_line_from_file(lang):
         f"```{lang}\n"
         "def sample(x):\n"
         "    return sqrt(x)\n"
-        "\n"
         "```\n"
     ), "Must contain selected lines in code in text"
     # fmt:on
@@ -69,10 +68,19 @@ def test_embed_code_only_specific_line_from_file(lang):
 def test_embed_code_only_specific_line_from_file_2():
     """```[lang]:[filepath] [line no] are available."""
     text_code = """```python:tests/src/sample.py[4-]\n```\n"""
-
     code_emb = get_code_emb()
     assert code_emb(text_code) == (
         "```python:tests/src/sample.py[4-]\n"
+        "def sample(x):\n"
+        "    return sqrt(x)\n"
+        "\n"
+        "```\n"
+    ), "Must contain selected lines in code in text"
+
+    text_code = """```python:tests/src/sample.py[4-6]\n```\n"""
+    code_emb = get_code_emb()
+    assert code_emb(text_code) == (
+        "```python:tests/src/sample.py[4-6]\n"
         "def sample(x):\n"
         "    return sqrt(x)\n"
         "\n"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+import pytest
+
 from markdown_embed_code import get_code_emb
 
 
@@ -40,3 +42,51 @@ def test_ignore_no_filepath():
     text = """```python\n```\n"""
     code_emb = get_code_emb()
     assert text == code_emb(text)
+
+
+@pytest.mark.parametrize(
+    "lang",
+    [
+        "python:tests/src/sample.py[4-6]",
+        "python:tests/src/sample.py [4-6]",
+    ],
+)
+def test_embed_code_only_specific_line_from_file(lang):
+    """```[lang]:[filepath] [line no] are available."""
+    code_emb = get_code_emb()
+    text_contains_code = f"""```{lang}\n```\n"""
+    # fmt:off
+    assert code_emb(text_contains_code) == (
+        f"```{lang}\n"
+        "def sample(x):\n"
+        "    return sqrt(x)\n"
+        "\n"
+        "```\n"
+    ), "Must contain selected lines in code in text"
+    # fmt:on
+
+
+def test_embed_code_only_specific_line_from_file_2():
+    """```[lang]:[filepath] [line no] are available."""
+    text_code = """```python:tests/src/sample.py[4-]\n```\n"""
+
+    code_emb = get_code_emb()
+    assert code_emb(text_code) == (
+        "```python:tests/src/sample.py[4-]\n"
+        "def sample(x):\n"
+        "    return sqrt(x)\n"
+        "\n"
+        "```\n"
+    ), "Must contain selected lines in code in text"
+
+    text_code = """```python:tests/src/sample.py[-3]\n```\n"""
+    code_emb = get_code_emb()
+    # fmt:off
+    assert code_emb(text_code) == (
+        "```python:tests/src/sample.py[-3]\n"
+        "from math import sqrt\n"
+        "\n"
+        "\n"
+        "```\n"
+    ), "Must contain selected lines in code in text"
+    # fmt:on


### PR DESCRIPTION
Add features:

* partially embedding: see readme at first. new syntax is available as ```lang:path[start-end]```. if you omit "start", embed from the first line and if you omit "end", embed to the last line. 