### PR TITLE
Update README.md by increasing backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ See [demo repo](https://github.com/tokusumi/readme-code-testing) if you are inte
 
 ## How to use
 
-In markdown, write code block as follows (notice that escape sequence "\\" must be eliminated):
+In markdown, write code block as follows:
 
-```markdown
-　\```python:tests/src/sample.py
- 
-　\```
+````markdown
+```python:tests/src/sample.py
 
-  And, you can refer specific lines as
-  \```python:tests/src/sample.py [4-5]
-  
-  \```
 ```
+
+And, you can refer specific lines as
+```python:tests/src/sample.py [4-5]
+ 
+```
+````
 
 Then, this action referes to `tests/src/sample.py` and modifies markdown as (if something code is written, they are overridden):
 


### PR DESCRIPTION
In the how to use section, a backlash is used to escape the sample how to use code:

```
　\```python:tests/src/sample.py
 
　\```

  And, you can refer specific lines as
  \```python:tests/src/sample.py [4-5]
  
  \```
```

But now is possible to add more backticks to fenced code blocks in order to allow triple backticks inside. For example the following fenced block uses backticks in order to be able to use an example of how the new README will show the sample

`````
````markdown
　```python:tests/src/sample.py
 
　```

  And, you can refer specific lines as
  ```python:tests/src/sample.py [4-5]
  
  ```
````
`````

Now there is no need to ask for the backslashes to be removed. I hope this helps.